### PR TITLE
added WI general registration deadlines

### DIFF
--- a/2018/g2018_vr.csv
+++ b/2018/g2018_vr.csv
@@ -48,7 +48,7 @@ VT,,,,,"Voters in Vermont can register to vote on any day, including Election Da
 VA,2018-10-15,2018-10-15,,,
 WA,2018-10-08,2018-10-08,,,
 WV,2018-10-16,2018-10-16,,,
-WI,,,,,
+WI,2018-11-06,2018-10-17,,,
 WY,,,,,
 AS,,,,,
 DC,,,,,

--- a/2018/g2018_vr.csv
+++ b/2018/g2018_vr.csv
@@ -48,7 +48,7 @@ VT,,,,,"Voters in Vermont can register to vote on any day, including Election Da
 VA,2018-10-15,2018-10-15,,,
 WA,2018-10-08,2018-10-08,,,
 WV,2018-10-16,2018-10-16,,,
-WI,2018-11-06,2018-10-17,,,
+WI,,,,,"Online: up to 20 days before the election. At the polling place on Election Day: you may register at the polls on Election Day."
 WY,,,,,
 AS,,,,,
 DC,,,,,


### PR DESCRIPTION
From the [Wisconsin Elections Commission](http://elections.wi.gov/sites/default/files/publication/154/voter_registration_guide_pdf_12830.pdf):

>Online. Up to 20 days before the election.

>At the polling place on Election Day. You may register at the polls on Election Day.