### PR TITLE
added ID general registration deadlines

### DIFF
--- a/2018/g2018_vr.csv
+++ b/2018/g2018_vr.csv
@@ -10,7 +10,7 @@ DE,2018-10-13,2018-10-13,,,Voters living overseas have until 10/22/2018 to regis
 FL,2018-10-09,2018-10-09,,,
 GA,2018-10-09,2018-10-09,,,
 HI,2018-10-09,2018-10-09,,,
-ID,,,,,
+ID,2018-11-06,2018-10-12,,,If a voter has not registered prior to Election Day, he or she may do so at the polling place.
 IL,2018-10-09,,,,"Voters in Illinois can register to vote on any day, including Election Day"
 IN,2018-10-09,2018-10-09,,,
 IA,,,,,

--- a/2018/g2018_vr.csv
+++ b/2018/g2018_vr.csv
@@ -10,7 +10,7 @@ DE,2018-10-13,2018-10-13,,,Voters living overseas have until 10/22/2018 to regis
 FL,2018-10-09,2018-10-09,,,
 GA,2018-10-09,2018-10-09,,,
 HI,2018-10-09,2018-10-09,,,
-ID,2018-11-06,2018-10-12,,,If a voter has not registered prior to Election Day, he or she may do so at the polling place.
+ID,2018-11-06,2018-10-12,,,If a voter has not registered prior to Election Day he or she may do so at the polling place.
 IL,2018-10-09,,,,"Voters in Illinois can register to vote on any day, including Election Day"
 IN,2018-10-09,2018-10-09,,,
 IA,,,,,


### PR DESCRIPTION
From the ID Secretary of State [Election Day Registration Procedural Manual](https://sos.idaho.gov/elect/clerk/Manuals/EDR2_ElectionDayRegistrationManual.pdf):

>If a voter has not registered prior to Election Day, he or she may do so at the polling place

The [online registration form](https://apps.idahovotes.gov/OnlineVoterRegistration) doesn't list a clear deadline. The [Voter Registration Application](https://idahovotes.gov/media/voter_registration.pdf) says:

>If mailed, this card must be postmarked by the 25th day before an election.

The [deadline calendar for 2017](https://idahovotes.gov/important-dates-for-voters/) states that the last day to pre-register for the 2017-11-07 election was 2017-10-13, which was 25 days prior.

So I used 25 days priory for the online registration deadline.