### PR TITLE
added DC general registration deadlines

### DIFF
--- a/2018/g2018_vr.csv
+++ b/2018/g2018_vr.csv
@@ -51,7 +51,7 @@ WV,2018-10-16,2018-10-16,,,
 WI,,,,,
 WY,,,,,
 AS,,,,,
-DC,,,,,
+DC,2018-11-06,2018-10-16,,,If otherwise qualified, you may register at your precinct’s polling place on Election Day and cast a regular ballot that same day.
 FM,,,,,
 GU,,,,,
 MH,,,,,

--- a/2018/g2018_vr.csv
+++ b/2018/g2018_vr.csv
@@ -51,7 +51,7 @@ WV,2018-10-16,2018-10-16,,,
 WI,,,,,
 WY,,,,,
 AS,,,,,
-DC,2018-11-06,2018-10-16,,,If otherwise qualified, you may register at your precinct’s polling place on Election Day and cast a regular ballot that same day.
+DC,2018-11-06,2018-10-16,,,If otherwise qualified you may register at your precinct’s polling place on Election Day and cast a regular ballot that same day.
 FM,,,,,
 GU,,,,,
 MH,,,,,


### PR DESCRIPTION
From the [DC Board of Elections](https://www.dcboe.org/faq/voter_reg.asp):

>Applications submitted by mail or online must be received by DCBOE no later than 21 days prior to Election Day.

>If otherwise qualified, you may register at your precinct’s polling place on Election Day and cast a regular ballot that same day.