### PR TITLE
added DC 2018 primary registration deadlines

### DIFF
--- a/2018/p2018_federal_vr.csv
+++ b/2018/p2018_federal_vr.csv
@@ -51,7 +51,7 @@ WV,,,,,
 WI,2018-07-25,2018-07-25,,,
 WY,,,,,
 AS,,,,,
-DC,,,,,
+DC,2018-06-19,2018-05-29,,,On Election Day qualified electors may register to vote and cast full ballots at the polling places for their precincts of residence
 FM,,,,,
 GU,,,,,
 MH,,,,,


### PR DESCRIPTION
From the [DC Board of Elections](https://www.dcboe.org/pdf_files/PrimaryElectionCalendar_061918.pdf):

>**Tuesday, May 29, 2018**
>Deadline for receipt of all voter registration applications (including federal postcard
applications (FPCAs)

>**TUESDAY, JUNE 19, 2018 – PRIMARY ELECTION DAY**
>On Election Day, between the hours of 7:00 a.m. to 8:00 p.m., qualified electors may
register to vote and cast full ballots at the polling places for their precincts of residence. 